### PR TITLE
scale-config: Add 2 gpu g3.8xlarge instances

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -26,3 +26,10 @@ runner_types:
     max_available: 100
     os: linux
     ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
+  linux.8xlarge.nvidia.gpu:
+    disk_size: 150
+    instance_type: g3.8xlarge
+    is_ephemeral: false
+    max_available: 100
+    os: linux
+    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64


### PR DESCRIPTION
This adds 2 gpu runners which are required for distributed unit tests such as needed in torchft.

https://github.com/pytorch/test-infra/blob/main/.github/scale-config.yml#L110C1-L115C50

To properly test things like NCCL in PyTorch we need two devices. This test in particular requires 2 GPUs https://github.com/pytorch-labs/torchft/blob/main/torchft/process_group_test.py#L113-L114

Test plan:

I'm not sure how to test this without landing it. Config matches existing configs on pytorch and pytorch-labs so should work