### PR TITLE
Remove ami key from pytorch-labs scale-config

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -11,25 +11,21 @@ runner_types:
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
   linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
   linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64
   linux.8xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.8xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.5.202*-kernel-6.1-x86_64


### PR DESCRIPTION
This key isn't actually necessary, should just use the default from our terraform deployment