### PR TITLE
Update scale config ami to 2023.7

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -11,46 +11,46 @@ runner_types:
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.6.202*-kernel-6.1-x86_64
+    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.6.202*-kernel-6.1-x86_64
+    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.6.202*-kernel-6.1-x86_64
+    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.8xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.8xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.6.202*-kernel-6.1-x86_64
+    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.g5.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.4xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.6.202*-kernel-6.1-x86_64
+    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.g5.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.12xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.6.202*-kernel-6.1-x86_64
+    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.g6e.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g6e.12xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.6.202*-kernel-6.1-x86_64
+    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -11,46 +11,39 @@ runner_types:
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.4xlarge:
     disk_size: 150
     instance_type: c5.4xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.4xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.8xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g3.8xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.g5.4xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.4xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.g5.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g5.12xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64
   linux.g6e.12xlarge.nvidia.gpu:
     disk_size: 150
     instance_type: g6e.12xlarge
     is_ephemeral: false
     max_available: 100
     os: linux
-    ami: al2023-ami-2023.7.202*-kernel-6.1-x86_64


### PR DESCRIPTION
Maybe help with eternal queueing on pytorch-labs?

Saw "Error: No availabe images found for filter 'al2023-ami-2023.6.202*-kernel-6.1-x86_64'" in scale up error logs